### PR TITLE
Strip leading ! or \ from DuckDuckGo query.

### DIFF
--- a/panel-plugin/verve-plugin.c
+++ b/panel-plugin/verve-plugin.c
@@ -138,15 +138,11 @@ verve_plugin_focus_timeout (VervePlugin *verve)
     {
       /* Make it look normal again */
       gtk_widget_modify_base (verve->input, GTK_STATE_NORMAL, &verve->default_style->base[GTK_STATE_NORMAL]);
-      gtk_widget_modify_bg (verve->input, GTK_STATE_NORMAL, &verve->default_style->bg[GTK_STATE_NORMAL]);
-      gtk_widget_modify_text (verve->input, GTK_STATE_NORMAL, &verve->default_style->text[GTK_STATE_NORMAL]);
     }
   else
     {
       /* Highlight the entry by changing base and background colors */
       gtk_widget_modify_base (verve->input, GTK_STATE_NORMAL, &style->base[GTK_STATE_SELECTED]);
-      gtk_widget_modify_bg (verve->input, GTK_STATE_NORMAL, &style->bg[GTK_STATE_SELECTED]);
-      gtk_widget_modify_text (verve->input, GTK_STATE_NORMAL, &style->text[GTK_STATE_SELECTED]);
     }
   
   return TRUE;
@@ -171,8 +167,6 @@ verve_plugin_focus_timeout_reset (VervePlugin *verve)
   
   /* Reset entry background */
   gtk_widget_modify_base (verve->input, GTK_STATE_NORMAL, &verve->default_style->base[GTK_STATE_NORMAL]);
-  gtk_widget_modify_bg (verve->input, GTK_STATE_NORMAL, &verve->default_style->bg[GTK_STATE_NORMAL]);
-  gtk_widget_modify_text (verve->input, GTK_STATE_NORMAL, &verve->default_style->text[GTK_STATE_NORMAL]);
 }
 
 

--- a/panel-plugin/verve.c
+++ b/panel-plugin/verve.c
@@ -200,7 +200,10 @@ verve_execute (const gchar *input,
   else if ((launch_params.use_bang && input[0] == '!') || (launch_params.use_backslash && input[0] == '\\'))
   {
     /* Launch DuckDuckGo */
-    gchar *esc_input = g_uri_escape_string(input, NULL, TRUE);
+    gchar *esc_input = input;
+    /* Remove leading ! or \ */
+    memmove(esc_input, esc_input+1, strlen(esc_input));
+    esc_input = g_uri_escape_string(esc_input, NULL, TRUE);
     command = g_strconcat ("exo-open https://duckduckgo.com/?q=", esc_input, NULL);
     g_free(esc_input);
   }


### PR DESCRIPTION
First commit is to strip the leading ! or \ used to initiate DuckDuckGo queries (currently these characters will be left in as part of the query).

Second commit fixes an issue with white text turning black on blur by removing the lines that revert the text and bg color to a default value on focus loss.